### PR TITLE
Disable vue sass source maps

### DIFF
--- a/packages/vue-sass/vue-sass.js
+++ b/packages/vue-sass/vue-sass.js
@@ -106,8 +106,8 @@ global.vue.lang.sass = Meteor.wrapAsync(function ({
     data: source,
     importer: resolveImport(dependencyManager),
     outFile: basePath + '.css',
-    sourceMap: true,
-    sourceMapContents: true,
+    sourceMap: false,
+    sourceMapContents: false,
     indentedSyntax: true,
   }, function (error, result) {
     if (error) {
@@ -115,7 +115,6 @@ global.vue.lang.sass = Meteor.wrapAsync(function ({
     } else {
       cb(null, {
         css: result.css.toString(),
-        map: result.map.toString(),
       })
     }
   })

--- a/packages/vue-sass/vue-sass.js
+++ b/packages/vue-sass/vue-sass.js
@@ -78,15 +78,14 @@ global.vue.lang.scss = Meteor.wrapAsync(function ({
     data: source,
     importer: resolveImport(dependencyManager),
     outFile: inputFile.getPathInPackage() + '.css',
-    sourceMap: true,
-    sourceMapContents: true,
+    sourceMap: false,
+    sourceMapContents: false,
   }, function (error, result) {
     if (error) {
       cb(error, null)
     } else {
       cb(null, {
         css: result.css.toString(),
-        map: result.map.toString(),
       })
     }
   })

--- a/packages/vue-sass/vue-sass.js
+++ b/packages/vue-sass/vue-sass.js
@@ -12,8 +12,6 @@ function resolveImport (dependencyManager) {
     url = url.replace(/^["']?(.*?)["']?$/, '$1')
     if (url.indexOf('~') === 0 || url.indexOf('/') === 0) {
       resolvedFilename = url.substr(1)
-    /* } else if (url.indexOf('{') === 0) {
-      resolvedFilename = decodeFilePath(url) */
     } else {
       let currentDirectory = path.dirname(prev === 'stdin' ? this.options.outFile : prev)
       resolvedFilename = path.resolve(currentDirectory, url)
@@ -65,19 +63,6 @@ function discoverImportPath (importPath) {
 
   return null
 }
-
-// function decodeFilePath (filePath) {
-//   const match = filePath.match(/^{(.*)}\/(.*)$/)
-//   if (!match)
-//     {throw new Error('Failed to decode Sass path: ' + filePath)}
-
-//   if (match[1] === '') {
-//     // app
-//     return match[2]
-//   }
-
-//   return 'packages/' + match[1] + '/' + match[2]
-// }
 
 global.vue.lang.scss = Meteor.wrapAsync(function ({
   source,


### PR DESCRIPTION
Disable CSS source maps for vue-sass package.

The CSS source maps don't appear to be available to the developer, and references to the maps are included in the production builds.